### PR TITLE
Added signal names and repr.

### DIFF
--- a/signalslot/signal.py
+++ b/signalslot/signal.py
@@ -45,9 +45,10 @@ class Signal(object):
     >>> conf_pre_load.is_connected(yourmodule_conf)
     False
     """
-    def __init__(self, args=None):
+    def __init__(self, args=None, name=None):
         self.slots = []
         self.args = args or []
+        self.name = name
 
     def connect(self, slot):
         """
@@ -117,3 +118,6 @@ class Signal(object):
         True
         """
         return self.slots == other.slots
+
+    def __repr__(self):
+        return '<signalslot.Signal: %s>' % (self.name or 'NO_NAME')

--- a/signalslot/tests.py
+++ b/signalslot/tests.py
@@ -68,6 +68,16 @@ class TestSignal(object):
         self.signal_a.disconnect(self.slot_b)
 
 
+def test_anonymous_signal_has_nice_repr():
+    signal = Signal()
+    assert repr(signal) == '<signalslot.Signal: NO_NAME>'
+
+
+def test_named_signal_has_a_nice_repr():
+    signal = Signal(name='update_stuff')
+    assert repr(signal) == '<signalslot.Signal: update_stuff>'
+
+
 class TestSignalConnect(object):
     def setup_method(self, method):
         self.signal = Signal()


### PR DESCRIPTION
repr is `<signalslot.Signal: signal_name>`.

For unamed signals, it is `<signalslot.Signal: NO_NAME>`. The ugly caps
are to make sure you notice you are calling repr on a signal with no
name, which you shouldn't.
