### PR TITLE
add RTD documentation badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@
     :target: https://crate.io/packages/signalslot
 .. image:: https://coveralls.io/repos/Numergy/signalslot/badge.png 
     :target: https://coveralls.io/r/Numergy/signalslot
+.. image:: https://readthedocs.org/projects/signalslot/badge/?version=latest
+    :target: https://signalslot.readthedocs.org/en/latest
 
 signalslot: simple Signal/Slot implementation for Python
 ========================================================


### PR DESCRIPTION
There's a RTFD link on the repo description but it is easy to miss.
Personally I directly head to the README, and I found it annoying
that the documentation is referred to (pattern section) but there is
no link to the documentation.
Adding a RTD badge is a common solution to this, it's easy to
find the project documentation then.