### PR TITLE
Add missing 'weakrefmethod' module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - TOX_ENV=pep8
   - TOX_ENV=py34
 install:
-  - pip install tox coveralls weakrefmethod
+  - pip install tox coveralls
 script:
   - tox -e $TOX_ENV
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         'six',
         'contexter',
+        'weakrefmethod',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/signalslot/__init__.py
+++ b/signalslot/__init__.py
@@ -1,11 +1,5 @@
 from .signal import Signal
 from .slot import Slot
-
-try:
-    from .slot import TornadoSlot
-except:
-    pass
-
 from .exceptions import *
 
 __version__ = '0.1.0'

--- a/signalslot/__init__.py
+++ b/signalslot/__init__.py
@@ -1,5 +1,10 @@
-from .signal import Signal
-from .slot import Slot
-from .exceptions import *
+try:
+    from .signal import Signal
+    from .slot import Slot
+    from .exceptions import *
+except ImportError: # pragma: no cover
+    # Possible we are running from setup.py, in which case we're after
+    # the __version__ string only.
+    pass
 
 __version__ = '0.1.0'

--- a/signalslot/__init__.py
+++ b/signalslot/__init__.py
@@ -2,7 +2,7 @@ try:
     from .signal import Signal
     from .slot import Slot
     from .exceptions import *
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     # Possible we are running from setup.py, in which case we're after
     # the __version__ string only.
     pass


### PR DESCRIPTION
This was missed, possibly because I didn't know how it was done at the
time.  The module really should declare this dependency up front so that
`pip install` pulls it in automatically.

This fixes issues like the following:
https://travis-ci.org/mriehl/fysom/jobs/104513915