### PR TITLE
MNT: bump minimum version of python to 3.4 and extend tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.coverage
+htmlcov/
+*__pycache__
+*.egg-info
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
 language: python
-python: 3.8
-env:
-  - TOX_ENV=pep8
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=py36
-  - TOX_ENV=py37
-  - TOX_ENV=py38
+dist: xenial
+
+matrix:
+  include:
+     - python: 3.8
+       env:
+         - TOX_ENV=pep8
+     - python: 3.4
+       env:
+         - TOX_ENV=py34
+     - python: 3.5
+       env:
+         - TOX_ENV=py35
+     - python: 3.6
+       env:
+         - TOX_ENV=py36
+     - python: 3.7
+       env:
+         - TOX_ENV=py37
+     - python: 3.8
+       env:
+         - TOX_ENV=py38
 install:
   - pip install tox coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
-python: 2.7
+python: 3.8
 env:
-  - TOX_ENV=py27
   - TOX_ENV=pep8
   - TOX_ENV=py34
+  - TOX_ENV=py35
+  - TOX_ENV=py36
+  - TOX_ENV=py37
+  - TOX_ENV=py38
 install:
   - pip install tox coveralls
 script:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     install_requires=[
         'six',
         'contexter',
-        'weakrefmethod',
     ],
+    python_requires='>=3.4',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -34,4 +34,3 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )
-

--- a/signalslot/signal.py
+++ b/signalslot/signal.py
@@ -91,7 +91,7 @@ class Signal(object):
         Connect a callback ``slot`` to this signal.
         """
         if not isinstance(slot, BaseSlot) and \
-                inspect.getargspec(slot).keywords is None:
+                inspect.getfullargspec(slot).varkw is None:
             raise exceptions.SlotMustAcceptKeywords(self, slot)
 
         with self._slots_lk:

--- a/signalslot/slot.py
+++ b/signalslot/slot.py
@@ -4,15 +4,9 @@ Module defining the Slot class.
 
 import types
 import weakref
-import sys
 
 from .signal import BaseSlot
-
-# We cannot test a branch for Python >= 3.4 in Python < 3.4.
-if sys.version_info < (3, 4):  # pragma: no cover
-    from weakrefmethod import WeakMethod
-else:  # pragma: no cover
-    from weakref import WeakMethod
+from weakref import WeakMethod
 
 
 class Slot(BaseSlot):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,9 +2,8 @@ mock
 eventlet
 pep8
 pytest
-pytest-cov<2.6
+pytest-cov
 pytest-pep8
 pytest-sugar
 pytest-xdist
-coverage==3.7.1
-weakrefmethod
+coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pep8,py34
+envlist = pep8,py34,py35,py36,py37,py38
 
 [testenv]
 commands = py.test --doctest-modules signalslot


### PR DESCRIPTION
This removes the dependency on weakrefmethod