### PR TITLE
Temporary and async slots support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ cover-erase=1
 cover-html-dir=build
 
 [tool:pytest]
-addopts = --pep8 --cov signalslot --cov-report html --doctest-modules
+addopts = --cov signalslot --cov-report html --doctest-modules
 python_files = signalslot/*.py
 norecursedirs = .git docs .tox
 looponfailroots = signalslot

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,4 +6,5 @@ pytest-cov
 pytest-pep8
 pytest-sugar
 pytest-xdist
+pytest-asyncio
 coverage


### PR DESCRIPTION
* added @slot decorator to connect callbacks
* added once() method to create temporary slots and ensure slot called just once and/or during provided timeout
* added async_emit() awaitable to allow library usage in asynchronous context and await async callbacks
* added tests for the above functions
* removed deprecated --pep8 flag from pytest config